### PR TITLE
Compilation error due to mutable variable 

### DIFF
--- a/ntk/numeric/levenberg_marquart_minimizer.cpp
+++ b/ntk/numeric/levenberg_marquart_minimizer.cpp
@@ -63,7 +63,7 @@ public:
   }
 
 private:
-  mutable CostFunction& m_cost_function;
+  CostFunction& m_cost_function;
   mutable std::vector<double> m_current_input;
   mutable std::vector<double> m_current_output;
   int m_input_dimension;


### PR DESCRIPTION
Fix error: reference ‘m_cost_function’ cannot be declared ‘mutable’ [-fpermissive]
