### PR TITLE
Depth data should use CV_INTER_NN interpolation.

### DIFF
--- a/ntk/camera/rgbd_processor.cpp
+++ b/ntk/camera/rgbd_processor.cpp
@@ -571,7 +571,7 @@ namespace ntk
             remap(m_image->rawDepthRef(), m_image->depthRef(),
                   m_image->calibration()->depth_undistort_map1,
                   m_image->calibration()->depth_undistort_map2,
-                  CV_INTER_LINEAR);
+                  CV_INTER_NN);
             ntk_assert(m_image->depth().data != 0, "Should be ok");
         }
         else


### PR DESCRIPTION
When using freenect backend, raw depth data is not interpolatable. Approximately speaking, 0~1023 represents normal values, while 2047 represents invalid depth. So liner interpolation between 2047 and other values is meaningless.
